### PR TITLE
Support percentages for width, pass e not num to callback

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,24 +4,24 @@ function doClick(e) {
 
 $.tbar1.init(['One', 'Two', 'Three'], callback);
 
-function callback(index) {
-	alert('You clicked button ' + (index+1));
+function callback(e) {
+	alert('You clicked button ' + (e.index+1));
 }
 
 
 var tbar2Buttons = ['NO', 'YES']
 $.tbar2.init(tbar2Buttons, tbar2Callback);
 
-function tbar2Callback(index) {
-	alert('You clicked  ' + tbar2Buttons[index]);
+function tbar2Callback(e) {
+	alert('You clicked  ' + tbar2Buttons[e.index]);
 }
 
 var tbar3Buttons = ['Blue', 'Yellow', 'Argggh!']
 $.tbar3.init(tbar3Buttons, tbar3Callback);
 $.tbar3.disableButton(2);
 
-function tbar3Callback(index) {
-	alert('You clicked  ' + tbar3Buttons[index]);
+function tbar3Callback(e) {
+	alert('You clicked  ' + tbar3Buttons[e.index]);
 }
 
 

--- a/app/styles/index.tss
+++ b/app/styles/index.tss
@@ -12,7 +12,7 @@
 	}
 }
 ".segmentedcontrol": {
-	width: 300,
+	width: '85%',
 	height: 60,
 	top: 10,
 	borderRadius: 4,

--- a/app/widgets/com.skypanther.segmentedcontrol/controllers/widget.js
+++ b/app/widgets/com.skypanther.segmentedcontrol/controllers/widget.js
@@ -21,30 +21,36 @@ var callback = function () {}; // empty function as placeholder
 
 var buttons = [];
 exports.init = function (labels, cb) {
-	var wrapperWidthIsCalculated = false;
+	var wrapperWidthIsCalculated = false,
+		calculatedWidth;
 	if (typeof cb == 'function') callback = cb;
 	if (!labels || !_.isArray(labels) || labels.length === 0) {
 		labels = ['Yes', 'No'];
 	}
 	// calculate button width
 	if (OS_ANDROID) {
-		if (isNaN(parseInt($.segCtrlWrapper.width))) {
-			$.segCtrlWrapper.width = Ti.Platform.displayCaps.platformWidth / Ti.Platform.displayCaps.logicalDensityFactor;
+		if ($.segCtrlWrapper.width.slice(-1) === '%') {
+			calculatedWidth = Ti.Platform.displayCaps.platformWidth / Ti.Platform.displayCaps.logicalDensityFactor * parseInt($.segCtrlWrapper.width)/100;
+		} else if (isNaN(parseInt($.segCtrlWrapper.width))) {
+			calculatedWidth = Ti.Platform.displayCaps.platformWidth / Ti.Platform.displayCaps.logicalDensityFactor;
 			wrapperWidthIsCalculated = true;
 		}
 	} else if (OS_IOS) {
-		if (isNaN(parseInt($.segCtrlWrapper.width))) {
+		if ($.segCtrlWrapper.width.slice(-1) === '%') {
+			calculatedWidth = Ti.Platform.displayCaps.platformWidth * parseInt($.segCtrlWrapper.width)/100;
+			console.log('Calculated the width of ' + args.id + ' to be ' + calculatedWidth);
+		} else if (isNaN(parseInt($.segCtrlWrapper.width))) {
 			// iOS handles rotation, but the wrapper width needs to be calculated to be
 			// the smaller of the height or width to avoid layout issues
 			if (Ti.Platform.displayCaps.platformWidth < Ti.Platform.displayCaps.platformHeight) {
-				$.segCtrlWrapper.width = Ti.Platform.displayCaps.platformWidth;
+				calculatedWidth = Ti.Platform.displayCaps.platformWidth;
 			} else {
-				$.segCtrlWrapper.width = Ti.Platform.displayCaps.platformHeight;
+				calculatedWidth = Ti.Platform.displayCaps.platformHeight;
 			}
 		}
 	}
 
-	var btnWidth = parseInt($.segCtrlWrapper.width) / labels.length;
+	var btnWidth = calculatedWidth / labels.length;
 	if (OS_ANDROID) btnWidth += 'dp';
 
 	// make our buttons
@@ -99,7 +105,12 @@ exports.init = function (labels, cb) {
 				}
 			}
 		});
-		callback(clickedButton);
+		callback({
+			index: clickedButton,
+			source: {
+				id: args.id || undefined
+			}
+		});
 	});
 };
 

--- a/readme.md
+++ b/readme.md
@@ -52,8 +52,8 @@ Initialize it in the controller:
 ```javascript
 $.tbar1.init(['One', 'Two', 'Three'], callback);
 
-function callback(index) {
-	alert('You clicked button ' + (index+1));
+function callback(e) {
+	alert('You clicked button ' + (e.index+1));
 }
 ```
 
@@ -77,7 +77,7 @@ Additionally, most other properties you set on the widget (via its xml tag or id
 
 |Method|Notes|
 |-------|--------------|
-|`init(labels, callback)`|You must call this method to initialize the control, passing to it an array of labels and a function to be called when a button is tapped. That function will receive a single parameter, the `index` of the button that was tapped|
+|`init(labels, callback)`|You must call this method to initialize the control, passing to it an array of labels and a function to be called when a button is tapped. That function will receive an object whose `index` property is the number of the button that was tapped|
 |`select(num)`| Selects the button specified|
 |`deselect(num)`| Deselects (unselects) the button specified|
 |`enable()`| Enables click events for the whole control|
@@ -94,7 +94,6 @@ Additionally, most other properties you set on the widget (via its xml tag or id
 * I haven't tested it on a tablet. Layout might be screwed up.
 * I'm pretty sure it won't handle rotation of the device well.
 * It doesn't support anything fancy, like icons instead of text on the buttons.
-* The `callback()` function should probably get an `e` object with more than just the `index` property.
 
 Contributions are welcome!
 


### PR DESCRIPTION
- Add support for setting the control's width as a percentage rather then explicit value.
- Pass an object whose `index` property is the number of the button tapped to the callback function rather than the number.
